### PR TITLE
Fix project complete and delete operations

### DIFF
--- a/src/omnifocus/scripts/projects.ts
+++ b/src/omnifocus/scripts/projects.ts
@@ -358,8 +358,7 @@ export const COMPLETE_PROJECT_SCRIPT = `
     }
     
     // Complete the project
-    targetProject.status = app.Project.Status.done;
-    targetProject.completionDate = new Date();
+    targetProject.markComplete();
     
     return JSON.stringify({
       success: true,
@@ -419,8 +418,8 @@ export const DELETE_PROJECT_SCRIPT = `
       }
     }
     
-    // Delete the project
-    targetProject.remove();
+    // Delete the project using JXA app.delete method
+    app.delete(targetProject);
     
     return JSON.stringify({
       success: true,


### PR DESCRIPTION
## Summary

Two bug fixes for project lifecycle operations:

1. **Complete project** - `complete_project` was failing with `TypeError: undefined is not an object (evaluating 'app.Project.Status.done')`
2. **Delete project** - `delete_project` was failing with `Error: Parameter is missing`

## Changes

- Use `markComplete()` instead of setting `app.Project.Status.done` (the Status enum isn't available in the JXA context)
- Use `app.delete(targetProject)` instead of `targetProject.remove()` (matches the pattern already used in `DELETE_TASK_SCRIPT`)

## Testing

Tested both operations via MCP - create project, complete project, create project, delete project all work correctly now.

Thanks for building this MCP - the architecture is solid and made these fixes straightforward to identify and test.